### PR TITLE
删去了架构章节中异步管理中的重复内容

### DIFF
--- a/docs/10.md
+++ b/docs/10.md
@@ -175,7 +175,6 @@ HBase 2.0 中引入了一种新 API，旨在提供异步访问 HBase 的能力�
 
 对于 `AsyncAdmin` 接口，大多数方法与旧的 `Admin` 接口具有相同的含义，返回值通常被 CompletableFuture 包装。
 
-For region name, we only accept `byte[]` as the parameter type and it may be a full region name or a encoded region name. For server name, we only accept `ServerName` as the parameter type. For table name, we only accept `TableName` as the parameter type. For `list*` operations, we only accept `Pattern` as the parameter type if you want to do regex matching.
 对于大多数管理操作，当返回的 CompletableFuture 完成时，也意味着管理操作已完成。但是对于压缩操作，它只意味着压缩请求被发送到 HBase 并且可能需要一些时间来完成压缩操作。对于 `rollWALWriter` 方法，它只表示 rollWALWriter 请求被发送到 region server，可能需要一些时间来完成 `rollWALWriter` 操作。
 
 对于 region 名称，只接受 `byte[]` 类型的参数，它可以是完整的 region 名称或编码后的 region 名称。对于服务器名称，只接受 `ServerName` 类型的参数。 对于表名，只接受 `TableName` 类型的参数。 对于 `list*` 操作，如果想要进行正则表达式匹配，只接受 `Pattern` 类型的参数。


### PR DESCRIPTION
在**68.4 异步管理**中有一段文字翻译过了，但是在前面出现了英文原文，属于重复内容，为了避免其他开发者产生疑惑，我把它删去了。